### PR TITLE
Updated de.catkeys

### DIFF
--- a/src/Daemon/locales/de.catkeys
+++ b/src/Daemon/locales/de.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.Einsteinium_Daemon	134140810
+1	German	application/x-vnd.Einsteinium_Daemon	134140810
 <Name not found>	AppRelaunchSettings.cpp	Keep first and last < >	<Name nicht gefunden>
 No	BApplication(einsteinium_daemon.cpp)	Alert button label	Nein
 Yes	BApplication(einsteinium_daemon.cpp)	Alert button label	Ja

--- a/src/Launcher/locales/de.catkeys
+++ b/src/Launcher/locales/de.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.Einsteinium_Engine	419800861
+1	German	application/x-vnd.Einsteinium_Engine	419800861
 Exclude	'Apps' list	Added to application label when modifier key pressed	Ausschließen
 Exclude from Apps list	'Apps' list	Application pop-up menu	Von Anwendungsliste ausschließen
 Launch	'Apps' list	Application pop-up menu	Starten
@@ -29,7 +29,7 @@ OK	Launcher application	Button label	OK
 The Einsteinium Launcher sent an invalid subscription to the Engine.  Please check your Launcher settings.	Launcher application	Failed subscription warning message	Der Einsteinium Launcher hat eine ungültige Indizierung zur Engine gesandt. Bitte die Launcher Einstellungen überprüfen.
 The Einsteinium Engine is not running.  Without the Engine the Launcher's Apps list will be populated from Haiku's recent applications list.  Do you wish to start the Engine now?	Launcher application	Warning message when Engine is not running	Die Einsteinium Engine wurde nicht gestartet. Ohne die Engine wird die Anwendungsliste des Launchers mit Haikus Liste der letzten Anwendungen befüllt. Soll die Engine jetzt gestartet werden?
 Apps	Launcher tabs	Tab label	Anwendungen
-Files	Launcher tabs	Tab label	Files
+Files	Launcher tabs	Tab label	Dateien
 Folders & Queries	Launcher tabs	Tab label	Ordner & Queries
 does not have an application signature	Settings 'App Exclusions' tab	Alert message	hat keine Anwendungs-Signatur
 Exclude These Apps From The Launcher	Settings 'App Exclusions' tab	Box label	Diese Anwendungen vom Launcher ausschließen.
@@ -37,7 +37,7 @@ Add…	Settings 'App Exclusions' tab	Button label	Hinzu…
 OK	Settings 'App Exclusions' tab	Button label	OK
 Remove	Settings 'App Exclusions' tab	Button label	Entfernen
 Applications in this list will be excluded from the Launcher.	Settings 'App Exclusions' tab	List tooltip	Anwendungen in dieser Liste tauchen im Launcher nicht auf.
-Apps Exclusions	Settings 'App Exclusions' tab	Tab label	Apps Exclusions
+Apps Exclusions	Settings 'App Exclusions' tab	Tab label	Ausnahmen
 Application Ranking Weights	Settings 'Apps Ranking' tab	Box label	Gewichtung der Anwendungs-Ränge
 Date of most recent launch:	Settings 'Apps Ranking' tab	Box label	Datum des letzten Starts:
 Date of very first launch:	Settings 'Apps Ranking' tab	Box label	Datum des ersten Starts:
@@ -58,7 +58,7 @@ minimally decrease the rank	Settings 'Apps Ranking' tab	Slider label part 2	den 
 minimally increase the rank	Settings 'Apps Ranking' tab	Slider label part 2	den Rang minimal erhöhen
 moderately decrease the rank	Settings 'Apps Ranking' tab	Slider label part 2	den Rang moderat verringern
 moderately increase the rank	Settings 'Apps Ranking' tab	Slider label part 2	den Rang moderat erhöhen
-slightly decrease the rank	Settings 'Apps Ranking' tab	Slider label part 2	den nur Rang leicht verringern
+slightly decrease the rank	Settings 'Apps Ranking' tab	Slider label part 2	den Rang nur leicht verringern
 slightly increase the rank	Settings 'Apps Ranking' tab	Slider label part 2	den Rang leicht erhöhen
 very heavily decrease the rank	Settings 'Apps Ranking' tab	Slider label part 2	den Rang sehr stark verringern
 very heavily increase the rank	Settings 'Apps Ranking' tab	Slider label part 2	den Rang sehr stark erhöhen
@@ -69,7 +69,7 @@ the most recent date and time the application was launched.	Settings 'Apps Ranki
 the total cumulative running time of the application since its first launch.	Settings 'Apps Ranking' tab	Slider tooltip part 2	die sich ansammelnde Laufzeit der Anwendung seit ihrem ersten Start.
 the total number of times the application has been launched.	Settings 'Apps Ranking' tab	Slider tooltip part 2	der Anzahl der bisherigen Anwendungssstarts.
 the very first date and time the application was launched.	Settings 'Apps Ranking' tab	Slider tooltip part 2	Datum und Zeit des ersten Starts der Anwendung.
-Apps Ranking	Settings 'Apps Ranking' tab	Tab label	Apps Ranking
+Apps Ranking	Settings 'Apps Ranking' tab	Tab label	Rangfolge
 Apps	Settings 'Layout' tab	Box label	Anwendungen
 Files, Folders and Queries	Settings 'Layout' tab	Box label	Dateien, Ordner und Queries
 Show Deskbar App List	Settings 'Layout' tab	Checkbox label	Deskbar Anwendungsliste zeigen
@@ -88,4 +88,4 @@ No Border	Settings 'Layout' tab	Window look menu item	Ohne Rahmen
 No Title Bar	Settings 'Layout' tab	Window look menu item	Ohne Fensterreiter
 Normal Title Bar	Settings 'Layout' tab	Window look menu item	Normale Fensterreiter
 Small Title Bar	Settings 'Layout' tab	Window look menu item	Kleine Fensterreiter
-Einsteinium Launcher Settings	Settings window	Settings window title	Einsteinium Launcher Settings
+Einsteinium Launcher Settings	Settings window	Settings window title	Einsteinium Launcher Einstellungen

--- a/src/Preferences/locales/de.catkeys
+++ b/src/Preferences/locales/de.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.Einsteinium_Preferences	3299147149
+1	German	application/x-vnd.Einsteinium_Preferences	3299147149
 <Name not found>	AppRelaunchSettings.cpp	Keep first and last < >	<Name nicht gefunden>
 Executable does not have an application signature	Daemon relaunch view	Alert message	Die ausführbare Datei besitzt keine Anwendungs-Signatur
 Application Relaunch Settings	Daemon relaunch view	Box label	Einstellungen für den Neustart von Anwendungen
@@ -28,16 +28,16 @@ The Launcher settings are set within the Launcher application.  Click the button
 Einsteinium provides smarter monitoring of applications and system services for Haiku.  Currently the two major functions implimented are automatically restarting applications and system services that quit or crash, and gathering statistics on application usage to provide customizable ranked lists of applications.\n\nThis preferences application is used to set options for the Einsteinium Daemon and Engine.  See each application's main section to get more details.	Main Window	About text	Einsteinium bietet eine intelligente Überwachung von Anwendungen und Diensten in Haiku. Die beiden Hauptfunktionen sind zur Zeit das automatische Neustarten von Anwendungen und Diensten nach deren Beendigung oder Absturz und das Sammeln von Nutzungsdaten für die Erstellung von benutzerdefinierten Listen benutzter Anwendungen.\n\nDieses Einstellungspanel dient der Konfiguration von Einsteinium Daemon und Engine. Für mehr Details, siehe die entsprechenden Sektionen dieser Module.
 About Einsteinium Preferences	Main Window	Box label	Über Einsteinium Preferences
 Einsteinium Copyright 2013 by Brian Hill	Main Window	Copyright text	Einsteinium Copyright 2013 von Brian Hill
-App Relaunch	Main Window	List label	App Relaunch
+App Relaunch	Main Window	List label	App Neustart
 Daemon	Main Window	List label	Daemon
 Engine	Main Window	List label	Engine
 Launcher	Main Window	List label	Launcher
-Maintenance	Main Window	List label	Maintenance
-Einsteinium Preferences	Main Window	Window title	Einsteinium Preferences
+Maintenance	Main Window	List label	Datenpflege
+Einsteinium Preferences	Main Window	Window title	Einsteinium Einstellungen
 Error: Could not create messenger for service 	Status box	Alert message	Fehler: Der Messenger für den Dienst konnte nicht erstellt werden.
 Restart	Status box	Button label	Neustart
 Start	Status box	Button label	Start
-Stop	Status box	Button label	Stop
+Stop	Status box	Button label	Stopp
 Restarting...	Status box	Status 'Restarting...' text	Neustart...
 Running	Status box	Status 'Running' text	Läuft
 Starting...	Status box	Status 'Starting...' text	Startet...


### PR DESCRIPTION
Here you are.
Have a look at https://lut.im/mRCpn82yFD/BvV690BhoewPDF0L.png

There are untranslated strings ("Other" etc.), which also don't use the B_SELECTED_ITEM_LIST_COLOR (or whatever that constant is called...).

With the tab view and the scroll bar, there are also quite a few borders in that window that might be joined with the window border etc., especially on the right side. Not sure how easy that is though, maybe just a few +1/-1 insets here and there?

Finally, I'm only able to build via haikuporter for some reason. what does the _${f:0:1}objects as OBJ_DIR do? Doesn't seem to work when doing it manually in Terminal.

